### PR TITLE
Try unicodedata for ETB if curses.ascii raises ImportError

### DIFF
--- a/dovado.py
+++ b/dovado.py
@@ -23,7 +23,12 @@ Options:
 import logging
 from datetime import timedelta
 from contextlib import contextmanager, closing
-from curses.ascii import ETB
+try:
+    import curses.ascii
+    ETB = chr(curses.ascii.ETB)
+except ImportError:
+    import unicodedata
+    ETB = unicodedata.lookup('ETB')
 import telnetlib
 import json
 from sys import argv
@@ -86,7 +91,7 @@ class Dovado():
         _log('skip', ret)
         ret = self._until(cursor)
         self._write(cmd + '\n')
-        ret = self._until(chr(ETB))[:-1]
+        ret = self._until(ETB)[:-1]
         _log('recv', ret)
         return ret
 


### PR DESCRIPTION
This should enable dovado to work on Python installations that don't have curses support built in -- the curses import will cause an ImportError with them.

Looking up `ETB` or `END OF TRANSMISSION BLOCK` doesn't seem to work on Python 2 for me though, but does on 3. But I think that's enough of an improvement.